### PR TITLE
Fixed an Issue Where Provided Source Directories Would Cause a Crash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as fh:
 
 MAJOR = 0
 MINOR = 3
-PATCH = 0
+PATCH = 1
 
 name = "subete"
 version = f"{MAJOR}.{MINOR}"

--- a/subete/repo.py
+++ b/subete/repo.py
@@ -420,3 +420,4 @@ class Repo:
             git.Repo.clone_from(
                 "https://github.com/TheRenegadeCoder/sample-programs.git", self._temp_dir.name)
             return os.path.join(self._temp_dir.name, "archive")
+        return source_dir


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "E:\Projects\sample-programs-docs-generator\generate_docs\generator.py", line 74, in <module>
    main_wiki()
  File "E:\Projects\sample-programs-docs-generator\generate_docs\generator.py", line 57, in main_wiki
    _create_generator().generate_wiki()
  File "E:\Projects\sample-programs-docs-generator\generate_docs\generator.py", line 45, in _create_generator
    generator = Generator(sys.argv[1])
  File "E:\Projects\sample-programs-docs-generator\generate_docs\generator.py", line 18, in __init__
    self.repo: Repo = Repo(source_dir=self.source_dir)
  File "E:\Projects\sample-programs-docs-generator\venv\lib\site-packages\subete\repo.py", line 346, in __init__
    self._languages: List[LanguageCollection] = self._collect_languages()
  File "E:\Projects\sample-programs-docs-generator\venv\lib\site-packages\subete\repo.py", line 404, in _collect_languages
    for root, directories, files in os.walk(self._source_dir):
  File "C:\Users\jerem\AppData\Local\Programs\Python\Python39\lib\os.py", line 342, in walk
    return _walk(fspath(top), topdown, onerror, followlinks)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```