### PR TITLE
Fixed an Issue Where Missing Programs Would Crash for Provided Repo

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+* v0.7.1
+  * Fixed a bug where the missing programs feature failed for provided repos 
+
+* v0.7.0
+  * Added Plausible support for analytics
+  * Added feature which allows us to retrieve list of missing programs for a language
+
 * v0.6.0
     * Added random program functionality
     * Fixed several documentation issues

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as fh:
 
 MAJOR = 0
 MINOR = 7
-PATCH = 0
+PATCH = 1
 
 name = "subete"
 version = f"{MAJOR}.{MINOR}"

--- a/subete/repo.py
+++ b/subete/repo.py
@@ -548,7 +548,7 @@ class Repo:
     def __init__(self, source_dir: Optional[str] = None) -> None:
         self._temp_dir = tempfile.TemporaryDirectory()
         self._source_dir: str = self._generate_source_dir(source_dir)
-        self._docs_dir: str = os.path.join(self._temp_dir.name, "docs")
+        self._docs_dir: str = self._generate_docs_dir(source_dir)
         self._projects: list[str] = self._collect_projects()
         self._languages: Dict[str: LanguageCollection] = self._collect_languages()
         self._total_snippets: int = sum(x.total_programs() for _, x in self._languages.items())
@@ -715,3 +715,17 @@ class Repo:
             return os.path.join(self._temp_dir.name, "archive")
         logger.info(f"Source directory provided: {source_dir}")
         return source_dir
+
+    def _generate_docs_dir(self, source_dir: Optional[str]) -> str:
+        """
+        A helper methods which generates the path to the documentation.
+        This method is needed because the provided source directory is meant
+        to point at archive (for historical purposes). This is normally
+        a non-issue if the directory is generated using Git, but can be more
+        annoying if the user provides a source. 
+
+        :return: a path to the documentation directory
+        """
+        if not source_dir:
+            return os.path.join(self._temp_dir.name, "docs")
+        return os.path.join(source_dir, os.pardir, "docs")

--- a/subete/repo.py
+++ b/subete/repo.py
@@ -468,7 +468,7 @@ class LanguageCollection:
 
             missing_programs: List[str] = language.missing_programs()
 
-        return: a list of missing sample programs
+        :return: a list of missing sample programs
         """
         return self._missing_programs
 
@@ -482,7 +482,7 @@ class LanguageCollection:
 
             missing_programs_count: int = language.missing_programs_count()
 
-        return: the number of missing sample programs
+        :return: the number of missing sample programs
         """
         return len(self._missing_programs)
 


### PR DESCRIPTION
Subete works just fine if the repo is downloaded fresh. However, things start to break if a user provides a path to an existing repo. I believe that's fixed now. 