### PR TITLE
Updated Sample Programs Website URL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ contents. It is currently in its alpha form, but you can already
 see it being used in various Sample Programs projects. 
 
 If you're interested in exploring the repo programatically,
-check out the [official documentation](https://subete.therenegadecoder.com). 
+check out the [official documentation](https://subete.jeremygrifski.com). 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* v0.8.0
+    * Updated URL from sample-programs.therenegadecoder.com to sampleprograms.io
+
 * v0.7.2
     * Fixed a bug where the missing programs list shared the entire path 
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 MAJOR = 0
-MINOR = 7
-PATCH = 2
+MINOR = 8
+PATCH = 0
 
 name = "subete"
 version = f"{MAJOR}.{MINOR}"

--- a/subete/repo.py
+++ b/subete/repo.py
@@ -626,7 +626,7 @@ class Repo:
         """
         A convenience method for retrieving a random program from the repository.
 
-        Assuming you have a Repo object called repo, here’s how you would use 
+        Assuming you have a Repo object called repo, here's how you would use 
         this method::
 
             program: SampleProgram = repo.random_program()

--- a/subete/repo.py
+++ b/subete/repo.py
@@ -135,10 +135,10 @@ class SampleProgram:
         and therefore not validated. The requirements documentation 
         URL is in the following form:
 
-        ``https://sample-programs.therenegadecoder.com/projects/{project}/``
+        ``https://sampleprograms.io/projects/{project}/``
 
         For example, here is a link to the
-        `Hello World documentation <https://sample-programs.therenegadecoder.com/projects/hello-world/>`_. 
+        `Hello World documentation <https://sampleprograms.io/projects/hello-world/>`_. 
 
         Assuming you have a SampleProgram object called program, 
         here's how you would use this method::
@@ -156,10 +156,10 @@ class SampleProgram:
         and therefore not validated. The documentation 
         URL is in the following form:
 
-        ``https://sample-programs.therenegadecoder.com/projects/{project}/{lang}/``
+        ``https://sampleprograms.io/projects/{project}/{lang}/``
 
         For example, here is a link to the
-        `Hello World in Python documentation <https://sample-programs.therenegadecoder.com/projects/hello-world/python/>`_. 
+        `Hello World in Python documentation <https://sampleprograms.io/projects/hello-world/python/>`_. 
 
         Assuming you have a SampleProgram object called program, 
         here's how you would use this method::
@@ -216,7 +216,7 @@ class SampleProgram:
 
         :return: the expected requirements URL 
         """
-        doc_url_base = "https://sample-programs.therenegadecoder.com/projects"
+        doc_url_base = "https://sampleprograms.io/projects"
         if "export" in self._normalized_name or "import" in self._normalized_name:
             return f"{doc_url_base}/import-export"
         else:
@@ -266,7 +266,7 @@ class LanguageCollection:
         self._sample_programs: Dict[str, SampleProgram] = self._collect_sample_programs()
         self._test_file_path: Optional[str] = self._collect_test_file()
         self._read_me_path: Optional[str] = self._collect_readme()
-        self._lang_docs_url: str = f"https://sample-programs.therenegadecoder.com/languages/{self._name}"
+        self._lang_docs_url: str = f"https://sampleprograms.io/languages/{self._name}"
         self._testinfo_url: str = f"https://github.com/TheRenegadeCoder/sample-programs/blob/main/archive/{self._name[0]}/{self._name}/testinfo.yml"
         self._total_snippets: int = len(self._sample_programs)
         self._total_dir_size: int = sum(x.size() for _, x in self._sample_programs.items())
@@ -424,10 +424,10 @@ class LanguageCollection:
         to exist and therefore not validated. The language documentation URL is
         in the following form:
 
-        ``https://sample-programs.therenegadecoder.com/languages/{lang}/``
+        ``https://sampleprograms.io/languages/{lang}/``
 
         For example, here is a link to the
-        `Python documentation <https://sample-programs.therenegadecoder.com/languages/python/>`_. 
+        `Python documentation <https://sampleprograms.io/languages/python/>`_. 
 
         Assuming you have a LanguageCollection object called language, 
         here's how you would use this method::

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,12 +6,12 @@ TEST_REPO = subete.load()
 
 def test_doc_url_multiword_lang():
     language: LanguageCollection = TEST_REPO["Google Apps Script"]
-    assert language.lang_docs_url() == "https://sample-programs.therenegadecoder.com/languages/google-apps-script"
+    assert language.lang_docs_url() == "https://sampleprograms.io/languages/google-apps-script"
 
 
 def test_doc_url_symbol_lang():
     language: LanguageCollection = TEST_REPO["C#"]
-    assert language.lang_docs_url() == "https://sample-programs.therenegadecoder.com/languages/c-sharp"
+    assert language.lang_docs_url() == "https://sampleprograms.io/languages/c-sharp"
 
 
 def test_testinfo_url_multiword_lang():
@@ -26,22 +26,22 @@ def test_testinfo_url_symbol_lang():
 
 def test_requirements_url_multiword_lang():
     program: SampleProgram = TEST_REPO["Google Apps Script"]["Hello World"]
-    assert program.requirements_url() == "https://sample-programs.therenegadecoder.com/projects/hello-world"
+    assert program.requirements_url() == "https://sampleprograms.io/projects/hello-world"
 
 
 def test_requirements_url_symbol_lang():
     program: SampleProgram = TEST_REPO["C#"]["Hello World"]
-    assert program.requirements_url() == "https://sample-programs.therenegadecoder.com/projects/hello-world"
+    assert program.requirements_url() == "https://sampleprograms.io/projects/hello-world"
 
 
 def test_documentation_url_multiword_lang():
     program: SampleProgram = TEST_REPO["Google Apps Script"]["Hello World"]
-    assert program.documentation_url() == "https://sample-programs.therenegadecoder.com/projects/hello-world/google-apps-script"
+    assert program.documentation_url() == "https://sampleprograms.io/projects/hello-world/google-apps-script"
 
 
 def test_documentation_url_symbol_lang():
     program: SampleProgram = TEST_REPO["C#"]["Hello World"]
-    assert program.documentation_url() == "https://sample-programs.therenegadecoder.com/projects/hello-world/c-sharp"
+    assert program.documentation_url() == "https://sampleprograms.io/projects/hello-world/c-sharp"
 
 
 def test_article_issue_url_multiword_lang():

--- a/tests/test_language_collection.py
+++ b/tests/test_language_collection.py
@@ -47,7 +47,7 @@ def test_language_collection_total_line_count():
 
 def test_language_collection_language_url():
     test = LanguageCollection(TEST_LANG, TEST_PATH, TEST_FILES, TEST_PROJECTS)
-    assert test.lang_docs_url() == "https://sample-programs.therenegadecoder.com/languages/python"
+    assert test.lang_docs_url() == "https://sampleprograms.io/languages/python"
 
 
 def test_missing_programs():

--- a/tests/test_sample_program.py
+++ b/tests/test_sample_program.py
@@ -32,12 +32,12 @@ def test_sample_program_size():
 
 def test_sample_program_requirements_url():
     test = SampleProgram(TEST_FILE_PATH, TEST_FILE_NAME, TEST_LANG)
-    assert test.requirements_url() == "https://sample-programs.therenegadecoder.com/projects/hello-world"
+    assert test.requirements_url() == "https://sampleprograms.io/projects/hello-world"
 
 
 def test_sample_program_documentation_url():
     test = SampleProgram(TEST_FILE_PATH, TEST_FILE_NAME, TEST_LANG)
-    assert test.documentation_url() == "https://sample-programs.therenegadecoder.com/projects/hello-world/python"
+    assert test.documentation_url() == "https://sampleprograms.io/projects/hello-world/python"
 
 
 def test_sample_program_issue_query_url():


### PR DESCRIPTION
Recently, I updated from a subdomain (sample-programs.therenegadecoder.com) to an actual domain (sampleprograms.io). Changes need to be made to ensure the new URLs are used. 