### PR TITLE
Changed the Way Project Names Are Generated

### DIFF
--- a/subete/repo.py
+++ b/subete/repo.py
@@ -910,7 +910,7 @@ class SampleProgram:
             url = stem.replace("_", "-").lower()
         else:
             # TODO: this is brutal. At some point, we should loop in the glotter test file.
-            url = re.sub('((?<=[a-z])[A-Z0-9]|(?!^)[A-Z](?=[a-z]))', r'-\1', stem).lower()
+            url = "-".join(re.sub('([A-Z][a-z]+)', r' \1', re.sub('([A-Z]+)', r' \1', stem)).split()).lower()
         logger.info(f"Constructed a normalized form of the program {url}")
         for project in projects:
             if url in project.pathlike_name():

--- a/tests/c/rot13.c
+++ b/tests/c/rot13.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+void rot13(char *str) {
+    for(int i = 0; str[i] != '\0'; i++) {
+        char c = *(str + i);
+        if(('a' <= c && 'n' > c) || ('A' <= c && 'N' > c)) {
+            *(str + i) += 13;
+        } else if(('n' <= c && 'z' >= c) || ('N' <= c && 'Z' >= c)) {
+            *(str + i) -= 13;
+        }
+    }
+}
+
+int main(int argc, char *argv[]) {
+    if(argc == 2 && strlen(argv[1]) != 0 && !isdigit(*argv[1])) {
+        rot13(argv[1]);
+        printf("%s\n", argv[1]);
+    } else {
+        printf("Usage: please provide a string to encrypt\n");
+    }
+    
+    return 0;
+}

--- a/tests/test_sample_program.py
+++ b/tests/test_sample_program.py
@@ -1,5 +1,6 @@
 from typing import List
 import subete
+from subete.repo import LanguageCollection
 
 TEST_PATH: str = "tests/python/"
 TEST_LANG: str = "python"
@@ -7,6 +8,7 @@ TEST_FILES: List[str] = ["hello_world.py", "testinfo.yml", "README.md"]
 TEST_PROJECTS: List[subete.Project] = [
     subete.Project("hello-world", {"words": ["hello", "world"], "requires_parameters": False}), 
     subete.Project("reverse-string", {"words": ["reverse", "string"], "requires_parameters": True}),
+    subete.Project("rot13", {"words": ["rot13"], "requires_parameters": False}),
 ]
 TEST_LANG_COLLECTION: subete.LanguageCollection = subete.LanguageCollection(
     TEST_LANG, 
@@ -56,3 +58,16 @@ def test_sample_program_issue_query_url():
     test = subete.SampleProgram(TEST_PATH, TEST_FILES[0], TEST_LANG_COLLECTION)
     assert test.article_issue_query_url(
     ) == "https://github.com//TheRenegadeCoder/sample-programs-website/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+hello+world+python"
+
+def test_generate_project_hyphen_branch():
+    test = subete.SampleProgram(
+        "tests/c", 
+        "rot13.c", 
+        LanguageCollection(
+            "c",
+            "tests/c",
+            ["rot13.c", "testinfo.yml", "README.md"],
+            TEST_PROJECTS
+        )
+    )
+    assert test.project_pathlike_name() == "rot13"


### PR DESCRIPTION
Previously, I had a REGEX that would parse CamelCase and numbers. So, things like Rot13 would automatically parse as rot-13. I don't want that behavior anymore. ROT13 should be a single token. 