### PR TITLE
Bug: Crash in `Repo._load_git_data` when `.git-blame-ignore-revs` does not exist (again)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as fh:
 
 MAJOR = 0
 MINOR = 15
-PATCH = 0
+PATCH = 1
 
 name = "subete"
 version = f"{MAJOR}.{MINOR}"

--- a/subete/repo.py
+++ b/subete/repo.py
@@ -263,7 +263,7 @@ class Repo:
 
         # Make sure .git-blame-ignore-revs exists for older versions of git and
         # keep track of whether it existed before
-        blame_path = Path(f"{self._sample_programs_temp_dir.name}/.git-blame-ignore-revs")
+        blame_path = Path(f"{self._sample_programs_repo_dir}/.git-blame-ignore-revs")
         blame_path_exists = blame_path.exists()
         blame_path.touch()
 


### PR DESCRIPTION
I fixed #59 