### PR TITLE
Add ability to get information about untestable languages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 Below you'll find all the changes that have been made to the code with
 newest changes first.
 
+0.18.x
+------
+
+* v0.18.0
+  * Add ability to get information about untestable languages.
+  * Indicate support for python 3.11.
+
 0.17.x
 ------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ newest changes first.
 * v0.18.0
   * Add ability to get information about untestable languages.
   * Indicate support for python 3.11.
+  * Upgrade PyYAML dependency to 6.x.
 
 0.17.x
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.pytest.ini_options]
 log_cli = true
-log_cli_level = "INFO"
+log_cli_level = "WARNING"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 log_file = "log.log"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-PyYAML==5.4.1
-pytest==6.2.4
-pytest-cov==2.12.1
-GitPython==3.1.18
+PyYAML==6.0.1
+pytest==7.4.3
+pytest-cov==4.1.0
+GitPython==3.1.40
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires=">=3.7",
     install_requires=[
-        "PyYAML>=5",
-        "GitPython>=3"
+        "PyYAML>=6,<7",
+        "GitPython>=3,<4"
     ],
     classifiers=[
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 MAJOR = 0
-MINOR = 17
+MINOR = 18
 PATCH = 0
 
 name = "subete"
@@ -39,6 +39,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "Topic :: Documentation :: Sphinx",
         "Development Status :: 3 - Alpha"

--- a/tests/mathematica/reverse-string.nb
+++ b/tests/mathematica/reverse-string.nb
@@ -1,0 +1,23 @@
+(* Code *)
+
+(* The actual function operating on Mathematica strings is just the built-in StringReverse.  An outer function provides the 'user interface': *)
+
+stringReverseMain = Function[{s},
+   Catch[
+    StringReverse[
+     If[
+      StringQ[s] \[And] \[Not] StringMatchQ[s, ""],
+      s,
+      Throw["Usage: please provide a string"]]]]];
+
+
+(* Valid Tests *)
+
+Print /@ stringReverseMain /@ {
+    "Hello, World"
+    };
+
+
+(* Invalid Tests *)
+
+stringReverseMain[""]

--- a/tests/mathematica/untestable.yml
+++ b/tests/mathematica/untestable.yml
@@ -1,0 +1,1 @@
+- reason: "Mathematica requires a commercial license, so it cannot be tested"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,8 +10,8 @@ SAMPLE_PROGRAMS_WEBSITE_TEMP_DIR = tempfile.TemporaryDirectory()
 
 
 def test_doc_url_multiword_lang(test_repo):
-    language: subete.LanguageCollection = test_repo["Google Apps Script"]
-    assert language.lang_docs_url() == "https://sampleprograms.io/languages/google-apps-script"
+    language: subete.LanguageCollection = test_repo["Commodore Basic"]
+    assert language.lang_docs_url() == "https://sampleprograms.io/languages/commodore-basic"
 
 
 def test_doc_url_symbol_lang(test_repo):
@@ -20,9 +20,9 @@ def test_doc_url_symbol_lang(test_repo):
 
 
 def test_testinfo_url_multiword_lang(test_repo):
-    language: subete.LanguageCollection = test_repo["Google Apps Script"]
+    language: subete.LanguageCollection = test_repo["Commodore Basic"]
     assert language.testinfo_url(
-    ) == "https://github.com/TheRenegadeCoder/sample-programs/blob/main/archive/g/google-apps-script/testinfo.yml"
+    ) == "https://github.com/TheRenegadeCoder/sample-programs/blob/main/archive/c/commodore-basic/testinfo.yml"
 
 
 def test_testinfo_url_symbol_lang(test_repo):
@@ -31,8 +31,14 @@ def test_testinfo_url_symbol_lang(test_repo):
     ) == "https://github.com/TheRenegadeCoder/sample-programs/blob/main/archive/c/c-sharp/testinfo.yml"
 
 
+def test_untesting_info_url(test_repo):
+    language: subete.LanguageCollection = test_repo["Mathematica"]
+    assert language.untestable_info_url(
+    ) == "https://github.com/TheRenegadeCoder/sample-programs/blob/main/archive/m/mathematica/untestable.yml"
+
+
 def test_requirements_url_multiword_lang(test_repo):
-    program: subete.SampleProgram = test_repo["Google Apps Script"]["Hello World"]
+    program: subete.SampleProgram = test_repo["Commodore Basic"]["Hello World"]
     assert program.project().requirements_url(
     ) == "https://sampleprograms.io/projects/hello-world"
 
@@ -44,9 +50,9 @@ def test_requirements_url_symbol_lang(test_repo):
 
 
 def test_documentation_url_multiword_lang(test_repo):
-    program: subete.SampleProgram = test_repo["Google Apps Script"]["Hello World"]
+    program: subete.SampleProgram = test_repo["Commodore Basic"]["Hello World"]
     assert program.documentation_url(
-    ) == "https://sampleprograms.io/projects/hello-world/google-apps-script"
+    ) == "https://sampleprograms.io/projects/hello-world/commodore-basic"
 
 
 def test_documentation_url_symbol_lang(test_repo):
@@ -56,9 +62,9 @@ def test_documentation_url_symbol_lang(test_repo):
 
 
 def test_article_issue_url_multiword_lang(test_repo):
-    program: subete.SampleProgram = test_repo["Google Apps Script"]["Hello World"]
+    program: subete.SampleProgram = test_repo["Commodore Basic"]["Hello World"]
     assert program.article_issue_query_url(
-    ) == "https://github.com//TheRenegadeCoder/sample-programs-website/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+hello+world+google+apps+script"
+    ) == "https://github.com//TheRenegadeCoder/sample-programs-website/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+hello+world+commodore+basic"
 
 
 def test_article_issue_url_symbol_lang(test_repo):
@@ -120,7 +126,7 @@ def test_project_path(test_repo):
 
 
 def test_project_has_test(test_repo):
-    program: subete.SampleProgram = test_repo["Google Apps Script"]["Hello World"]
+    program: subete.SampleProgram = test_repo["Commodore Basic"]["Hello World"]
     assert program.project().has_testing()
 
 
@@ -134,6 +140,10 @@ def test_repo_total_programs(test_repo):
 
 def test_repo_total_tests(test_repo):
     assert test_repo.total_tests() > 0
+
+
+def test_repo_total_untestables(test_repo):
+    assert test_repo.total_untestables() > 0
 
 
 def test_repo_languages_by_letter(test_repo):

--- a/tests/test_language_collection.py
+++ b/tests/test_language_collection.py
@@ -9,6 +9,10 @@ TEST_PROJECTS: List[subete.Project] = [
     subete.Project("reverse-string", {"words": ["reverse", "string"], "requires_parameters": True}),
 ]
 
+UNTESTABLE_PATH: str = "tests/mathematica"
+UNTESTABLE_LANG: str = "mathematica"
+UNTESTABLE_FILES: List[str] = ["reverse-string.nb", "untestable.yml"]
+
 
 def test_language_collection_str():
     test = subete.LanguageCollection(TEST_LANG, TEST_PATH, TEST_FILES, TEST_PROJECTS)
@@ -23,6 +27,11 @@ def test_language_collection_name():
 def test_language_collection_test_file():
     test = subete.LanguageCollection(TEST_LANG, TEST_PATH, TEST_FILES, TEST_PROJECTS)
     assert test.testinfo() is not None
+
+
+def test_language_collection_untestable_file():
+    test = subete.LanguageCollection(UNTESTABLE_LANG, UNTESTABLE_PATH, UNTESTABLE_FILES, TEST_PROJECTS)
+    assert test.untestable_info() is not None
 
 
 def test_language_collection_readme():


### PR DESCRIPTION
Also, contains the following changes:

- Add support for python 3.11
- Upgrade dependencies
- Decrease test logging noise
- Change "Google Apps Script" tests to "Commodore Basic" tests since "Google Apps Script" language was deleted