### PR TITLE
Do not index sample programs that do not correspond to a valid project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ newest changes first.
 0.18.x
 ------
 
+* v0.18.1
+  * Do not index sample programs that do not correspond to a valid project.
+
 * v0.18.0
   * Add ability to get information about untestable languages.
   * Indicate support for python 3.11.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as fh:
 
 MAJOR = 0
 MINOR = 18
-PATCH = 0
+PATCH = 1
 
 name = "subete"
 version = f"{MAJOR}.{MINOR}"

--- a/subete/repo.py
+++ b/subete/repo.py
@@ -761,7 +761,11 @@ class LanguageCollection:
             _, file_ext = os.path.splitext(file)
             file_ext = file_ext.lower()
             if file_ext not in (".md", "", ".yml"):
-                program = SampleProgram(self._path, file, self)
+                try:
+                    program = SampleProgram(self._path, file, self)
+                except KeyError:
+                    continue
+
                 sample_programs[program.project_name()] = program
                 logger.debug(f"New sample program collected: {program}")
         sample_programs = dict(sorted(sample_programs.items()))
@@ -860,7 +864,10 @@ class SampleProgram:
         self._path: str = path
         self._file_name: str = file_name
         self._language: LanguageCollection = language
-        self._project: Project = self._generate_project()
+        self._project: Optional[Project] = self._generate_project()
+        if not self._project:
+            raise KeyError(f"Project cannot be found for {file_name}")
+
         self._sample_program_doc_url: str = self._generate_doc_url()
         self._sample_program_issue_url: str = self._generate_issue_url()
         self._line_count: int = len(self.code().splitlines())

--- a/tests/test_integration_for_bad_repo.py
+++ b/tests/test_integration_for_bad_repo.py
@@ -16,7 +16,7 @@ def test_bad_repo_languages(bad_test_repo):
 
 
 def test_bad_repo_total_programs(bad_test_repo):
-    assert bad_test_repo.total_programs() == 1
+    assert bad_test_repo.total_programs() == 0
 
 
 def test_bad_repo_total_tests(bad_test_repo):


### PR DESCRIPTION
I fixed #68 . I chose to just ignore a bad sample program name and move on as opposed to crashing. There will be an error in the log:
```
Could not find a project for <file_name> with name <url> in <project_names>
```

Also, updated the GitHub actions to fix this warning, for example:
[test (3.11)](https://github.com/TheRenegadeCoder/subete/actions/runs/7269609088/job/19807489796)
```
The following actions uses node12 which is deprecated and will be forced to run on node16: 
actions/checkout@v2, actions/setup-python@v2.
```