### PR TITLE
Handle filenames that have extensions with more than one dot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 Below you'll find all the changes that have been made to the code with
 newest changes first.
 
+0.19.x
+------
+
+* v0.19.0
+  * Support extensions with mulitple dots (like TI-Basic which has an extension
+    of `.8xp.txt`)
+  * Drop support for python 3.7.
+
 0.18.x
 ------
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 MAJOR = 0
-MINOR = 18
-PATCH = 2
+MINOR = 19
+PATCH = 0
 
 name = "subete"
 version = f"{MAJOR}.{MINOR}"
@@ -28,7 +28,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/TheRenegadeCoder/subete",
     packages=setuptools.find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "PyYAML>=6,<7",
         "GitPython>=3,<4"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as fh:
 
 MAJOR = 0
 MINOR = 18
-PATCH = 1
+PATCH = 2
 
 name = "subete"
 version = f"{MAJOR}.{MINOR}"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setuptools.setup(
     ],
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/subete/repo.py
+++ b/subete/repo.py
@@ -758,7 +758,9 @@ class LanguageCollection:
         """
         sample_programs = {}
         for file in self._file_list:
-            _, file_ext = os.path.splitext(file)
+            filename, file_ext = os.path.splitext(file)
+            if "." in filename:
+                file_ext = os.path.splitext(filename)[1] + file_ext
             file_ext = file_ext.lower()
             if file_ext not in (".md", "", ".yml"):
                 try:
@@ -1187,6 +1189,8 @@ class SampleProgram:
         """
         projects = self._language._projects
         stem = os.path.splitext(self._file_name)[0]
+        if "." in stem:
+            stem = os.path.splitext(stem)[0]
         if len(stem.split("-")) > 1:
             url = stem.lower()
         elif len(stem.split("_")) > 1:

--- a/tests/test_sample_program.py
+++ b/tests/test_sample_program.py
@@ -74,6 +74,19 @@ def test_generate_project_hyphen_branch():
     assert test.project_pathlike_name() == "rot13"
 
 
+def test_generate_project_multiple_extensions():
+    test = subete.SampleProgram(
+        "tests/ti-basic",
+        "hello-world.8xp.txt",
+        LanguageCollection(
+            "ti-basic",
+            "tests/ti-basic",
+            ["hello-world.8xp.txt", "testinfo.yml", "README.md"],
+            TEST_PROJECTS
+        )
+    )
+    assert test.project_pathlike_name() == "hello-world"
+
 def test_sample_program_equality():
     test1 = subete.SampleProgram(TEST_PATH, TEST_FILES[0], TEST_LANG_COLLECTION)
     test2 = subete.SampleProgram(TEST_PATH, TEST_FILES[0], TEST_LANG_COLLECTION)

--- a/tests/ti-basic/hello-world.8xp.txt
+++ b/tests/ti-basic/hello-world.8xp.txt
@@ -1,0 +1,1 @@
+Disp "Hello, World!"


### PR DESCRIPTION
I fixed #71 . I also had to drop support for python 3.7 since the latest version of `setup-python` no longer supports that version.